### PR TITLE
Revert "Feature/gateway regional endpoint (#16)"

### DIFF
--- a/aws/lambda/gateway/domain.tf
+++ b/aws/lambda/gateway/domain.tf
@@ -7,12 +7,8 @@ data "aws_route53_zone" "zone" {
 resource "aws_api_gateway_domain_name" "api_gateway_domain_name" {
   count = var.domain != null ? 1 : 0
 
-  regional_certificate_arn = var.domain.certificate_arn
+  certificate_arn = var.domain.certificate_arn
   domain_name     = var.domain.domain
-
-  endpoint_configuration {
-    types = ["REGIONAL"]
-  }
 }
 
 resource "aws_api_gateway_base_path_mapping" "base_path_mapping" {
@@ -30,8 +26,8 @@ resource "aws_route53_record" "api_gateway_domain_name_record" {
   type    = "A"
   zone_id = data.aws_route53_zone.zone.0.id
   alias {
-    name                   = aws_api_gateway_domain_name.api_gateway_domain_name.0.regional_domain_name
-    zone_id                = aws_api_gateway_domain_name.api_gateway_domain_name.0.regional_zone_id
+    name                   = aws_api_gateway_domain_name.api_gateway_domain_name.0.cloudfront_domain_name
+    zone_id                = aws_api_gateway_domain_name.api_gateway_domain_name.0.cloudfront_zone_id
     evaluate_target_health = false
   }
 }

--- a/examples/aws/api_gateway_with_domain/api_gateway_with_domain.tf
+++ b/examples/aws/api_gateway_with_domain/api_gateway_with_domain.tf
@@ -4,6 +4,8 @@ data "aws_acm_certificate" "acm_certificate" {
   domain      = "they-code.de"
   statuses    = ["ISSUED"]
   most_recent = true
+
+  provider = aws.acm_region
 }
 
 # --- RESOURCES / MODULES ---

--- a/examples/aws/api_gateway_with_domain/providers.tf
+++ b/examples/aws/api_gateway_with_domain/providers.tf
@@ -22,3 +22,15 @@ provider "aws" {
   }
 }
 
+// provider where domain certificates are stored
+provider "aws" {
+  alias  = "acm_region"
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Project   = "they-terraform-examples"
+      CreatedBy = "terraform"
+    }
+  }
+}


### PR DESCRIPTION
This reverts commit ebde1a487aeeb98fa44e3e339e81dc7138d8d550.
While tf deployment of example ran through smoothly, the module is now causing problems for actual implementation of the modules in cp-api. So for now we should revert this.

<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.

