### PR TITLE
Feat/14 api gateway with domain regional

### DIFF
--- a/aws/lambda/gateway/cert.tf
+++ b/aws/lambda/gateway/cert.tf
@@ -1,0 +1,24 @@
+resource "aws_acm_certificate" "cert" {
+  domain_name       = var.domain.domain
+  validation_method = "DNS"
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_dns" {
+  allow_overwrite = true
+  name =  tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_name
+  records = [tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_value]
+  type = tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_type
+  zone_id = data.aws_route53_zone.zone.0.id
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert_validate" {
+  certificate_arn = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_dns.fqdn]
+}

--- a/aws/lambda/gateway/domain.tf
+++ b/aws/lambda/gateway/domain.tf
@@ -14,6 +14,10 @@ resource "aws_api_gateway_domain_name" "api_gateway_domain_name" {
   endpoint_configuration {
     types = ["REGIONAL"]
   }
+
+  mutual_tls_authentication {
+    truststore_uri = var.trustStoreUri
+  }
 }
 
 resource "aws_api_gateway_base_path_mapping" "base_path_mapping" {

--- a/aws/lambda/gateway/domain.tf
+++ b/aws/lambda/gateway/domain.tf
@@ -5,10 +5,15 @@ data "aws_route53_zone" "zone" {
 }
 
 resource "aws_api_gateway_domain_name" "api_gateway_domain_name" {
+  depends_on = [aws_acm_certificate_validation.cert_validate]
   count = var.domain != null ? 1 : 0
 
-  certificate_arn = var.domain.certificate_arn
+  regional_certificate_arn = aws_acm_certificate_validation.cert_validate.certificate_arn
   domain_name     = var.domain.domain
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
 }
 
 resource "aws_api_gateway_base_path_mapping" "base_path_mapping" {
@@ -26,8 +31,8 @@ resource "aws_route53_record" "api_gateway_domain_name_record" {
   type    = "A"
   zone_id = data.aws_route53_zone.zone.0.id
   alias {
-    name                   = aws_api_gateway_domain_name.api_gateway_domain_name.0.cloudfront_domain_name
-    zone_id                = aws_api_gateway_domain_name.api_gateway_domain_name.0.cloudfront_zone_id
+    name                   = aws_api_gateway_domain_name.api_gateway_domain_name.0.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api_gateway_domain_name.0.regional_zone_id
     evaluate_target_health = false
   }
 }

--- a/aws/lambda/gateway/variables.tf
+++ b/aws/lambda/gateway/variables.tf
@@ -74,3 +74,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "trustStoreUri" {
+  description = "Uri to where the s3 truststore.pem for mTLS authorization is to be found."
+  type        = string
+  default     = null
+}

--- a/aws/lambda/gateway/variables.tf
+++ b/aws/lambda/gateway/variables.tf
@@ -57,7 +57,6 @@ variable "authorizer" {
 variable "domain" {
   description = "The domain configuration to use for the api gateway."
   type = object({
-    certificate_arn = string
     zone_name       = string
     domain          = string
   })
@@ -68,4 +67,10 @@ variable "redeployment_trigger" {
   description = "A unique string to force a redeploy of the api gateway. If not set manually, the module will use the configurations for endpoints, api_key, and authorizer config to decide if a redeployment is necessary."
   type        = string
   default     = null
+}
+
+variable "tags" {
+  description = "Tags for the resources."
+  type        = map(string)
+  default     = {}
 }

--- a/examples/aws/api_gateway_with_domain/api_gateway_with_domain.tf
+++ b/examples/aws/api_gateway_with_domain/api_gateway_with_domain.tf
@@ -1,13 +1,5 @@
 # --- DATA ---
 
-data "aws_acm_certificate" "acm_certificate" {
-  domain      = "they-code.de"
-  statuses    = ["ISSUED"]
-  most_recent = true
-
-  provider = aws.acm_region
-}
-
 # --- RESOURCES / MODULES ---
 
 module "lambda_api_gateway_with_domain" {
@@ -25,7 +17,6 @@ module "lambda_api_gateway_with_domain" {
   ]
 
   domain = {
-    certificate_arn = data.aws_acm_certificate.acm_certificate.arn
     zone_name       = "they-code.de."
     domain          = "they-test-lambda.they-code.de"
   }

--- a/examples/aws/api_gateway_with_domain/api_gateway_with_domain.tf
+++ b/examples/aws/api_gateway_with_domain/api_gateway_with_domain.tf
@@ -7,6 +7,7 @@ module "lambda_api_gateway_with_domain" {
   source = "../../../aws/lambda/gateway"
 
   name = "they-test-api-gateway-with-domain"
+  trustStoreUri = "s3://they-test-api-gateway-with-domain-assets/certificates/truststore.pem"
   endpoints = [
     {
       path          = "simple"

--- a/examples/aws/api_gateway_with_domain/providers.tf
+++ b/examples/aws/api_gateway_with_domain/providers.tf
@@ -21,16 +21,3 @@ provider "aws" {
     }
   }
 }
-
-// provider where domain certificates are stored
-provider "aws" {
-  alias  = "acm_region"
-  region = "us-east-1"
-
-  default_tags {
-    tags = {
-      Project   = "they-terraform-examples"
-      CreatedBy = "terraform"
-    }
-  }
-}


### PR DESCRIPTION
## Summary

closes #14 
Our [first try](https://github.com/THEY-Consulting/they-terraform/pull/16) at implementing this didn't sufficiently work with the cp-api setup we have.
The reason for this was that in cp-api we have the following setup:
- root CA: contipark-api.de is in us-east-1
- our api gateways are deployed in eu-central-1
- custom domains were using contipark-api.de directly as a cert, therefore the domains were all in us-east-1
- when we tested this in they-terraform we didn't run into this, as we simply happen to deploy to the same region for all things.
- in order to be able to enable mTLS we need to have the custom domain & apigateway in the same region
- solution: we create certs for the endpoints in the same region as the apigateway (DNS validation is still done via the root cert in the US I believe but this is handled by tf and aws), and then use these certs for the custom domains themselves

<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

- temporarily deploy a lambda with Api Gateway with a domain (little heads up deployment will take some time as cert creation and validation takes a hot minute, somewhere between 1.30-4.40 min, sometimes it goes really fast... most times it does not)
- `cd examples/aws/api_gateway_with_domain`
- `terraform init`
- `terraform apply`
- in aws browser console navigate to Api Gateway settings, and select Custom Domain Names, or click [here](https://eu-west-1.console.aws.amazon.com/apigateway/main/publish/domain-names?domain=prod-list-packages.they-code.de&region=eu-west-1)
- select the domain for the lambda you've just deployed
- select to edit in domain details section
- verify that you have the toggle to turn on mTLS
- go back one step to the details for your custom domain
- select edit in endpoint configuration
- verify that you are using the certificate your created (should have the same name as your custom domain)
- don't forget to destroy your deployment afterwards `terraform destroy` 

I already checked if this is compatible with cp-api, but if you want to run a double check, you can simulate the scenario we have in cp-api, by changing where you deploy your gateway + domain + cert, by altering line 15 to "eu-west-3"  in this file `examples/aws/api_gateway_with_domain/providers.tf` creating the scenario, where they-code.de has it's root CA in eu-west-1, and you deploy your gateway+plus cert + custom domain in a region differnt to that one.
- redo all the steps from above
 

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.

