### PR TITLE
declare aws providers in all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ module "lambda_with_build" {
 
 See https://developer.hashicorp.com/terraform/language/modules/sources#selecting-a-revision for more details.
 
+Specific providers can be set for modules by using the `providers` argument:
+
+```hcl
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "specific"
+}
+
+module "lambda_with_specific_provider" {
+  source = "github.com/THEY-Consulting/they-terraform//aws/lambda"
+
+  providers = {
+    aws = aws.specific
+  }
+}
+```
+
 ## Modules
 
 ### AWS

--- a/aws/lambda/gateway/providers.tf
+++ b/aws/lambda/gateway/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/aws/lambda/providers.tf
+++ b/aws/lambda/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/aws/openid/github/providers.tf
+++ b/aws/openid/github/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/aws/setup-tfstate/providers.tf
+++ b/aws/setup-tfstate/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/azure/function-app/providers.tf
+++ b/azure/function-app/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}

--- a/examples/aws/module_with_specific_provider/lambda_with_specific_provider.tf
+++ b/examples/aws/module_with_specific_provider/lambda_with_specific_provider.tf
@@ -1,0 +1,18 @@
+# --- RESOURCES / MODULES ---
+
+module "module_with_specifig_provider" {
+  # source = "github.com/THEY-Consulting/they-terraform//aws/lambda"
+  source = "../../../aws/lambda"
+
+  name        = "they-test-module-with-specific-provider"
+  description = "Test module with specific provider"
+  source_dir  = "../packages/lambda-typescript"
+  runtime     = "nodejs18.x"
+
+  # setting provider explicitly
+  providers = {
+    aws = aws.specific
+  }
+}
+
+# --- OUTPUT ---

--- a/examples/aws/module_with_specific_provider/providers.tf
+++ b/examples/aws/module_with_specific_provider/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.11.0"
+    }
+  }
+
+  required_version = "1.5.5"
+}
+
+// default provider that is used when no other provider
+// is specified explicitly
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "specific"
+
+  default_tags {
+    tags = {
+      Project   = "they-terraform-examples"
+      CreatedBy = "terraform"
+    }
+  }
+}


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

- test if setting a provider works by depoying _examples/aws/module_with_specific_provider_:
```
cd examples/aws/module_with_specific_provider
terraform init
terraform apply
```

- test if modules also work without setting a provider go to any other example folder and do the same
```
cd <some-other-example>
terraform init
terraform apply
```

remember to clean up the deployed examples with `terraform destroy`

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.

