### PR TITLE
Fix - missing tfstate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,12 @@
 .terraform.lock.hcl
 # Track these files only within the examples directory and its subdirectories.
 !**/examples/**/.terraform.lock.hcl
-!**/examples/**/terraform.tfstate
 
 # .tfstate files
 *.tfstate
 *.tfstate.*
+# Track this file only within the examples directory.
+!**/examples/.setup-tfstate/terraform.tfstate
 
 # Crash log files
 crash.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .terraform.lock.hcl
 # Track these files only within the examples directory and its subdirectories.
 !**/examples/**/.terraform.lock.hcl
+!**/examples/.setup-tfstate/*.tfstate
 
 # .tfstate files
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .terraform.lock.hcl
 # Track these files only within the examples directory and its subdirectories.
 !**/examples/**/.terraform.lock.hcl
-!**/examples/.setup-tfstate/terraform.tfstate
+!**/examples/**/terraform.tfstate
 
 # .tfstate files
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .terraform.lock.hcl
 # Track these files only within the examples directory and its subdirectories.
 !**/examples/**/.terraform.lock.hcl
-!**/examples/.setup-tfstate/*.tfstate
+!**/examples/.setup-tfstate/terraform.tfstate
 
 # .tfstate files
 *.tfstate

--- a/examples/.setup-tfstate/terraform.tfstate
+++ b/examples/.setup-tfstate/terraform.tfstate
@@ -1,0 +1,255 @@
+{
+  "version": 4,
+  "terraform_version": "1.6.4",
+  "serial": 7,
+  "lineage": "2493767a-bcb4-8975-58ef-423862ef9ea3",
+  "outputs": {},
+  "resources": [
+    {
+      "module": "module.setup_tfstate",
+      "mode": "managed",
+      "type": "aws_dynamodb_table",
+      "name": "tfstate_lock",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:dynamodb:eu-central-1:749963754311:table/they-terraform-examples-tfstate-lock",
+            "attribute": [
+              {
+                "name": "LockID",
+                "type": "S"
+              }
+            ],
+            "billing_mode": "PROVISIONED",
+            "deletion_protection_enabled": false,
+            "global_secondary_index": [],
+            "hash_key": "LockID",
+            "id": "they-terraform-examples-tfstate-lock",
+            "import_table": [],
+            "local_secondary_index": [],
+            "name": "they-terraform-examples-tfstate-lock",
+            "point_in_time_recovery": [
+              {
+                "enabled": true
+              }
+            ],
+            "range_key": null,
+            "read_capacity": 1,
+            "replica": [],
+            "restore_date_time": null,
+            "restore_source_name": null,
+            "restore_to_latest_time": null,
+            "server_side_encryption": [],
+            "stream_arn": "",
+            "stream_enabled": false,
+            "stream_label": "",
+            "stream_view_type": "",
+            "table_class": "STANDARD",
+            "tags": null,
+            "tags_all": {
+              "CreatedBy": "terraform",
+              "Project": "they-terraform-examples"
+            },
+            "timeouts": null,
+            "ttl": [
+              {
+                "attribute_name": "",
+                "enabled": false
+              }
+            ],
+            "write_capacity": 1
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxODAwMDAwMDAwMDAwLCJkZWxldGUiOjYwMDAwMDAwMDAwMCwidXBkYXRlIjozNjAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+        }
+      ]
+    },
+    {
+      "module": "module.setup_tfstate",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::they-terraform-examples-tfstate",
+            "bucket": "they-terraform-examples-tfstate",
+            "bucket_domain_name": "they-terraform-examples-tfstate.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_regional_domain_name": "they-terraform-examples-tfstate.s3.eu-central-1.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "4b8c648d858bbff0a3d21da644d124486582a680e5a9c0f6daf1d935af187703",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z21DNDUVLTQW6Q",
+            "id": "they-terraform-examples-tfstate",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "eu-central-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": null,
+            "tags_all": {
+              "CreatedBy": "terraform",
+              "Project": "they-terraform-examples"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "module": "module.setup_tfstate",
+      "mode": "managed",
+      "type": "aws_s3_bucket_policy",
+      "name": "bucket_policy",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "they-terraform-examples-tfstate",
+            "id": "they-terraform-examples-tfstate",
+            "policy": "{\"Id\":\"disallowHttp\",\"Statement\":[{\"Action\":\"s3:*\",\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"}},\"Effect\":\"Deny\",\"Principal\":\"*\",\"Resource\":[\"arn:aws:s3:::they-terraform-examples-tfstate\",\"arn:aws:s3:::they-terraform-examples-tfstate/*\"],\"Sid\":\"HTTPSOnly\"}],\"Version\":\"2012-10-17\"}"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.setup_tfstate.aws_s3_bucket.bucket"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.setup_tfstate",
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "they-terraform-examples-tfstate",
+            "id": "they-terraform-examples-tfstate",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.setup_tfstate.aws_s3_bucket.bucket"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.setup_tfstate",
+      "mode": "managed",
+      "type": "aws_s3_bucket_server_side_encryption_configuration",
+      "name": "encryption",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "they-terraform-examples-tfstate",
+            "expected_bucket_owner": "",
+            "id": "they-terraform-examples-tfstate",
+            "rule": [
+              {
+                "apply_server_side_encryption_by_default": [
+                  {
+                    "kms_master_key_id": "",
+                    "sse_algorithm": "AES256"
+                  }
+                ],
+                "bucket_key_enabled": null
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.setup_tfstate.aws_s3_bucket.bucket"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.setup_tfstate",
+      "mode": "managed",
+      "type": "aws_s3_bucket_versioning",
+      "name": "versioning",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "they-terraform-examples-tfstate",
+            "expected_bucket_owner": "",
+            "id": "they-terraform-examples-tfstate",
+            "mfa": null,
+            "versioning_configuration": [
+              {
+                "mfa_delete": "",
+                "status": "Enabled"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.setup_tfstate.aws_s3_bucket.bucket"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
The `terraform.tfstate` file for the deployment that configures the backend used by all the examples was not being tracked by the repo, since all `*.tfstate` files were being gitignored.

Now, only this `terraform.tfstate` file in the repo is not ignored.

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
