### PR TITLE
force instance refresh for asg on launch template changes or tag changes

### DIFF
--- a/aws/auto-scaling-group/auto-scaling-group.tf
+++ b/aws/auto-scaling-group/auto-scaling-group.tf
@@ -30,7 +30,6 @@ resource "aws_autoscaling_group" "asg" {
       # approach/solution was proposed here:
       # https://github.com/hashicorp/terraform-provider-aws/issues/16849#issuecomment-764941664
       LaunchTemplateVersion = aws_launch_template.launch_template.latest_version
-      NewTag                = "ok"
     })
     content {
       key                 = tag.key

--- a/aws/auto-scaling-group/auto-scaling-group.tf
+++ b/aws/auto-scaling-group/auto-scaling-group.tf
@@ -25,6 +25,8 @@ resource "aws_autoscaling_group" "asg" {
   dynamic "tag" {
     for_each = merge(data.aws_default_tags.current.tags, var.tags, {
       Name = var.name
+      # used to trigger refreshs based on tags. see: https://github.com/hashicorp/terraform-provider-aws/issues/16849#issuecomment-764941664
+      LaunchTemplateVersion = aws_launch_template.launch_template.latest_version
     })
     content {
       key                 = tag.key
@@ -32,6 +34,11 @@ resource "aws_autoscaling_group" "asg" {
       propagate_at_launch = true # Enables propagation of the tag to
       # Amazon EC2 instances launched via this ASG.
     }
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
+    triggers = ["tag"]
   }
 
 }

--- a/aws/auto-scaling-group/auto-scaling-group.tf
+++ b/aws/auto-scaling-group/auto-scaling-group.tf
@@ -25,8 +25,12 @@ resource "aws_autoscaling_group" "asg" {
   dynamic "tag" {
     for_each = merge(data.aws_default_tags.current.tags, var.tags, {
       Name = var.name
-      # used to trigger refreshs based on tags. see: https://github.com/hashicorp/terraform-provider-aws/issues/16849#issuecomment-764941664
+      # Allows enforcing instance_refresh when the launch_template changes. Only
+      # works when instance_refresh trigger "tag" is set. A somewhat similar
+      # approach/solution was proposed here:
+      # https://github.com/hashicorp/terraform-provider-aws/issues/16849#issuecomment-764941664
       LaunchTemplateVersion = aws_launch_template.launch_template.latest_version
+      NewTag                = "ok"
     })
     content {
       key                 = tag.key


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

When using this module and:

1. creating a new deployment (e.g. deploying a new version of application code and updating the 'Version' tag)
2. updating the launch_template (e.g. changing the user_data script)

the instances won't be refreshed. So we end up with a confusing state of
"deployment went through but nothing changed". This PR exists to fix this issue.

### PR instructions

-   apply this diff to avoid confusion when testing

```

diff --git a/examples/aws/auto-scaling-group-only-http/auto-scaling-group-only-http.tf b/examples/aws/auto-scaling-group-only-http/auto-scaling-group-only-http.tf
index 7fa02fb..aa5566a 100644
--- a/examples/aws/auto-scaling-group-only-http/auto-scaling-group-only-http.tf
+++ b/examples/aws/auto-scaling-group-only-http/auto-scaling-group-only-http.tf
@@ -13,9 +13,9 @@ module "auto-scaling-group" {
   name                = "${terraform.workspace}-they-terraform-asg-http"
   ami_id              = "ami-0ba27d9989b7d8c5d" # AMI valid for eu-central-1 (Amazon Linux 2023 arm64).
   instance_type       = "t4g.nano"
-  desired_capacity    = 2
+  desired_capacity    = 1
   min_size            = 1
-  max_size            = 3
+  max_size            = 1
   user_data_file_name = "user_data.sh"
   availability_zones  = data.aws_availability_zones.azs.names[*] # Use AZs of region defined by provider.
 }

```

-   deploy the examples/aws/auto-scaling-group-only-http example
    -   `cd examples/aws/auto-scaling-group-only-http`
    -   `tf init`
    -   `tf apply`
-   check the aws console for instances and note down the instance id and the
    launch time

case 1:

-   add a new tag to the resource. E.g. add

```

  tags = {
    NewTag = "test"
  }


```

to the auto-scaling-group.tf file.

-   deploy the example again, same steps as above
-   check the aws console, a new instance id with a new launch time should have
    been created

case 2:

-   apply this diff to the user_data.sh file

```

diff --git a/examples/aws/auto-scaling-group-only-http/user_data.sh b/examples/aws/auto-scaling-group-only-http/user_data.sh
index 625a1af..215bf9c 100644
--- a/examples/aws/auto-scaling-group-only-http/user_data.sh
+++ b/examples/aws/auto-scaling-group-only-http/user_data.sh
@@ -2,6 +2,6 @@
 # Respond with a webpage with the private IP of the instance on port 80.
 mkdir /var/www
 touch /var/www/index.html
-echo "<h1>Hostname: $(hostname -f)</h1>" > /var/www/index.html
+echo "<h1>UPDATED Hostname: $(hostname -f)</h1>" > /var/www/index.html
 cd /var/www
 python3 -m http.server 80

```

-   deploy the app (see above)
-   check the aws console, a new instance id with a new launch time should have
    been created

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
