### PR TITLE
remove db_name from rds module

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ module "rds_postgres_database" {
 
 | Variable                | Type        | Description                                                                                      | Required | Default          |
 | ----------------------- | ----------- | ------------------------------------------------------------------------------------------------ | -------- | ---------------- |
-| db_identifier           | string      | Unique name used to identify your database in the aws console                                    | yes      |                |
+| db_identifier           | string      | Unique name used to identify your database in the aws console                                    | yes      |                  |
 | engine                  | string      | Engine of the database                                                                           | no       | `"postgres"`     |
 | engine_version          | string      | Database's engine version                                                                        | no       | `"15.5"`         |
 | user_name               | string      | Main username for the database                                                                   | no       | `"psql"`         |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ module "rds_postgres_database" {
 
 | Variable                | Type        | Description                                                                                      | Required | Default          |
 | ----------------------- | ----------- | ------------------------------------------------------------------------------------------------ | -------- | ---------------- |
-| db_identifier           | string      | Unique name used to identify your database in the aws console                                    | no       | `"app"`          |
+| db_identifier           | string      | Unique name used to identify your database in the aws console                                    | yes      |                |
 | engine                  | string      | Engine of the database                                                                           | no       | `"postgres"`     |
 | engine_version          | string      | Database's engine version                                                                        | no       | `"15.5"`         |
 | user_name               | string      | Main username for the database                                                                   | no       | `"psql"`         |

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The location of all resources is always determined by the `region` of your aws `
 module "rds_postgres_database" {
   source = "github.com/THEY-Consulting/they-terraform//aws/database/rds"
 
-  db_name        = "app" # DBName must begin with a letter and contain only alphanumeric characters
+  db_identifier  = "dev-they-terraform-products" # Unique name used to identify your database in the aws console
   engine         = "postgres"
   engine_version = "15.5"
 
@@ -130,12 +130,12 @@ module "rds_postgres_database" {
 
 | Variable                | Type        | Description                                                                                      | Required | Default          |
 | ----------------------- | ----------- | ------------------------------------------------------------------------------------------------ | -------- | ---------------- |
-| db_name                 | string      | Name of the database                                                                             | no       | `"app"`          |
+| db_identifier           | string      | Unique name used to identify your database in the aws console                                    | no       | `"app"`          |
 | engine                  | string      | Engine of the database                                                                           | no       | `"postgres"`     |
 | engine_version          | string      | Database's engine version                                                                        | no       | `"15.5"`         |
 | user_name               | string      | Main username for the database                                                                   | no       | `"psql"`         |
 | password                | string      | Password of the main username for the database                                                   | yes      |                  |
-| allocated_storage       | number      | Allocated storage for the DB in GBs.                                                             | no       | `5`              |
+| allocated_storage       | number      | Allocated storage for the DB in GBs                                                              | no       | `5`              |
 | max_allocated_storage   | number      | Upper limit to which the RDS can automatically scale the storage of the db instance              | no       | `30`             |
 | instance_class          | string      | Instance class of database                                                                       | no       | `"db.t4g.micro"` |
 | multi_az                | bool        | Specifies whether the RDS is multi-AZ                                                            | no       | `false`          |
@@ -146,6 +146,7 @@ module "rds_postgres_database" {
 | apply_immediately       | bool        | Specifies whether db modifications are applied immediately or during the next maintenance window | no       | `true`           |
 | tags                    | map(string) | Map of tags to assign to the RDS instance and related resources                                  | no       | `{}`             |
 | vpc_cidr_block          | string      | CIDR blocj for the VPC                                                                           | no       | `"10.0.0.0/24"`  |
+| skip_final_snapshot     | bool        | Creates final DB snapshot when deleting the database. If true, no snapshot is created            | no       | `false`          |
 
 ##### Outputs
 
@@ -242,7 +243,7 @@ module "lambda" {
 ##### Inputs
 
 | Variable                      | Type         | Description                                                                                                                        | Required | Default                    |
-| ----------------------------- | ------------ |------------------------------------------------------------------------------------------------------------------------------------|----------|----------------------------|
+| ----------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
 | name                          | string       | Name of the lambda function                                                                                                        | yes      |                            |
 | description                   | string       | Description of the lambda function                                                                                                 | yes      |                            |
 | source_dir                    | string       | Directory containing the lambda function                                                                                           | yes      |                            |

--- a/aws/database/rds/database.tf
+++ b/aws/database/rds/database.tf
@@ -1,6 +1,5 @@
 resource "aws_db_instance" "main" {
-  db_name    = var.db_name
-  identifier = "${terraform.workspace}-${var.tags.Project}-${var.db_name}"
+  identifier = var.db_identifier
 
   engine                     = var.engine
   engine_version             = var.engine_version
@@ -23,7 +22,7 @@ resource "aws_db_instance" "main" {
   db_subnet_group_name   = aws_db_subnet_group.main.name
   vpc_security_group_ids = [aws_security_group.main.id]
 
-  skip_final_snapshot = true
+  skip_final_snapshot = var.skip_final_snapshot
   publicly_accessible = var.publicly_accessible
   apply_immediately   = var.apply_immediately
   tags                = var.tags

--- a/aws/database/rds/variables.tf
+++ b/aws/database/rds/variables.tf
@@ -1,7 +1,6 @@
-variable "db_name" {
-  description = "The name of the database."
+variable "db_identifier" {
+  description = "Unique name used to identify your database in the aws console"
   type        = string
-  default     = "app"
 }
 
 variable "engine" {
@@ -48,6 +47,12 @@ variable "instance_class" {
 
 variable "multi_az" {
   description = "Specifies if the RDS instance is multi-AZ."
+  type        = bool
+  default     = false
+}
+
+variable "skip_final_snapshot" {
+  description = "Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created."
   type        = bool
   default     = false
 }

--- a/aws/database/rds/vpc.tf
+++ b/aws/database/rds/vpc.tf
@@ -15,7 +15,7 @@ resource "aws_subnet" "instances_subnets" {
   availability_zone = data.aws_availability_zones.available.names[count.index]
 
   tags = {
-    Name = "${var.db_name}-subnet-${count.index}"
+    Name = "${var.db_identifier}-subnet-${count.index}"
   }
 }
 

--- a/examples/aws/rds_postgres_database/postgres_database.tf
+++ b/examples/aws/rds_postgres_database/postgres_database.tf
@@ -4,7 +4,7 @@ module "rds_postgres_database" {
   # source = "github.com/THEY-Consulting/they-terraform//aws/database/rds"
   source = "../../../aws/database/rds"
 
-  db_name        = "app" #DBName must begin with a letter and contain only alphanumeric characters
+  db_identifier  = "dev-they-terraform-products" # Unique name used to identify your database in the aws console
   engine         = "postgres"
   engine_version = "15.5"
   user_name      = "psql"


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

Removes the 'db_name' from our created rds database. This setting does create a default db when set. The problem is that the 'default db name' is immutable. When we want to do rename the database it won't let us to do without destroying and recreating it. The suggestion came from [here](https://stackoverflow.com/a/43106463) and we think the 'burden' of not being able to rename the database is larger/bigger/more impactful than having to create the database manually once.

### PR instructions

- deploy and destroy afterwards the example in `./examples/aws/rds_postgres_database/`
  - terraform init
  - terraform apply
  - terraform destroy

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
