### PR TITLE
fix of ASG output to return string

### DIFF
--- a/aws/auto-scaling-group/output.tf
+++ b/aws/auto-scaling-group/output.tf
@@ -1,9 +1,9 @@
 output "alb_dns" {
   description = "DNS of the application load balancer."
-  value       = var.loadbalancer_disabled ? null : aws_lb.lb[*].dns_name
+  value       = var.loadbalancer_disabled ? null : aws_lb.lb[0].dns_name
 }
 
 output "alb_zone_id" {
   description = "Zone ID of the application load balancer."
-  value       = var.loadbalancer_disabled ? null : aws_lb.lb[*].zone_id
+  value       = var.loadbalancer_disabled ? null : aws_lb.lb[0].zone_id
 }


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions
With the change in output, we should now get a string instead of a tuple. The change was necessary in the first place because the count attribute was set to make the Load-Balancer configurable.
- I tested by running the backend of core-api locally, by doing `terraform plan`, which is what failed in the github action and it seems to work 
<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
