### PR TITLE
add STORAGE_ACCOUNT_NAME to app_settings

### DIFF
--- a/azure/function-app/function_app-linux.tf
+++ b/azure/function-app/function_app-linux.tf
@@ -24,6 +24,9 @@ resource "azurerm_linux_function_app" "function_app" {
     var.identity != null ? {
       AZURE_CLIENT_ID = data.azurerm_user_assigned_identity.identity.0.client_id
     } : {},
+    {
+      STORAGE_ACCOUNT_NAME = data.azurerm_storage_account.storage_account.name
+    },
     var.environment
   )
 

--- a/azure/function-app/function_app-windows.tf
+++ b/azure/function-app/function_app-windows.tf
@@ -22,6 +22,9 @@ resource "azurerm_windows_function_app" "function_app" {
     var.identity != null ? {
       AZURE_CLIENT_ID = data.azurerm_user_assigned_identity.identity.0.client_id
     } : {},
+    {
+      STORAGE_ACCOUNT_NAME = data.azurerm_storage_account.storage_account.name
+    },
     var.environment
   )
 


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

This PR adds the `STORAGE_ACCOUNT_NAME` environment variable for azure functions. It's meant to expose the storage account name for functions, that don't have a storage trigger (e.g. `sync-arivo-carparks`), but still need to know what storage account they're associated with

### PR instructions

- review code changes
- ensure that the exposed value is the correct storage account name

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
