### PR TITLE
disable aws generated endoint url for AWS API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ module "lambda" {
     subnet_ids         = ["subnet-12345678"]
     security_group_ids = ["sg-12345678"]
   }
-  
+
   mount_efs = aws_efs_access_point.main.arn
 
   tags = {
@@ -248,7 +248,7 @@ module "lambda" {
 ##### Inputs
 
 | Variable                      | Type         | Description                                                                                                                        | Required | Default                    |
-|-------------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------|----------|----------------------------|
+| ----------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
 | name                          | string       | Name of the lambda function                                                                                                        | yes      |                            |
 | description                   | string       | Description of the lambda function                                                                                                 | yes      |                            |
 | source_dir                    | string       | Directory containing the lambda function                                                                                           | yes      |                            |
@@ -351,7 +351,7 @@ module "sns" {
 ##### Inputs
 
 | Variable                    | Type        | Description                                                                                | Required | Default         |
-| --------------------------- | ----------- |--------------------------------------------------------------------------------------------| -------- | --------------- |
+| --------------------------- | ----------- | ------------------------------------------------------------------------------------------ | -------- | --------------- |
 | access_policy               | string      | JSON representation of the access policy.                                                  | yes      |                 |
 | description                 | string      | Description of the SNS topic                                                               | yes      |                 |
 | name                        | string      | Name of the SNS topic                                                                      | yes      |                 |
@@ -420,7 +420,7 @@ module "sqs" {
 ##### Inputs
 
 | Variable                       | Type        | Description                                                                          | Required | Default  |
-|--------------------------------|-------------|--------------------------------------------------------------------------------------|----------|----------|
+| ------------------------------ | ----------- | ------------------------------------------------------------------------------------ | -------- | -------- |
 | access_policy                  | string      | JSON representation of the access policy.                                            | yes      |          |
 | description                    | string      | Description of the SQS                                                               | yes      |          |
 | name                           | string      | Name of the SQS                                                                      | yes      |          |
@@ -436,13 +436,12 @@ module "sqs" {
 ##### Outputs
 
 | Output                 | Type   | Description                                                                  |
-|------------------------|--------|------------------------------------------------------------------------------|
+| ---------------------- | ------ | ---------------------------------------------------------------------------- |
 | arn                    | string | The Amazon Resource Name (ARN) identifying your SQS                          |
 | queue_name             | string | The name of the SQS created                                                  |
 | topic_subscription_arn | string | The Amazon Resource Name (ARN) of the topic your SQS is subscribed to        |
 | dlq_arn                | string | The Amazon Resource Name (ARN) of the dead letter queue created for your sqs |
 | dlq_queue_name         | string | The name of the dead letter queue created for your SQS                       |
-
 
 #### API Gateway (REST)
 
@@ -487,7 +486,6 @@ module "api_gateway" {
   }
 
   domain = {
-    certificate_arn       = "some:certificate:arn"
     s3_truststore_uri     = "s3://they-test-api-gateway-with-domain-assets/certificates/truststore.pem"
     s3_truststore_version = data.aws_s3_object.truststore.version_id
     zone_name             = "they-code.de."
@@ -540,6 +538,7 @@ module "api_gateway" {
 | domain.s3_truststore_uri                  | string       | URI to truststore.pem used for verification of client certs (required if certificate_arn is not set)                                                                                                        | no       |                                                           |
 | domain.s3_truststore_version              | string       | version of truststore.pem used for verification of client certs (required if multiple versions of a trustore.pem exist)                                                                                     | no       |                                                           |
 | domain.zone_name                          | string       | Domain zone name                                                                                                                                                                                            | (yes)    |                                                           |
+| disable_default_endpoint                  | string       | Disable the aws generated default endpoint to the created gateway. Can be used to enforce requests only via custom domain. Always `true` if s3_truststore_uri is set.                                       | no       | `false`                                                   |
 | redeployment_trigger                      | string       | A unique string to force a redeploy of the api gateway. If not set manually, the module will use the configurations for endpoints, api_key, and authorizer config to decide if a redeployment is necessary. | (yes)    |                                                           |
 | tags                                      | map(string)  | Map of tags to assign to the Lambda Function and related resources                                                                                                                                          | no       | `{}`                                                      |
 
@@ -666,7 +665,7 @@ module "auto-scaling-group" {
 ##### Inputs
 
 | Variable                 | Type         | Description                                                                                                                                   | Required | Default         |
-|--------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
+| ------------------------ | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------- |
 | name                     | string       | Name of the Auto Scaling group (ASG)                                                                                                          | yes      |                 |
 | ami_id                   | string       | ID of AMI used in EC2 instances of ASG                                                                                                        | yes      |                 |
 | instance_type            | string       | Instance type used to deploy instances in ASG                                                                                                 | yes      |                 |
@@ -696,7 +695,7 @@ module "auto-scaling-group" {
 ##### Outputs
 
 | Output             | Type         | Description                                         |
-|--------------------|--------------|-----------------------------------------------------|
+| ------------------ | ------------ | --------------------------------------------------- |
 | alb_dns            | string       | DNS of the Application Load Balancer of the ASG     |
 | alb_zone_id        | string       | Zone ID of the Application Load Balancer of the ASG |
 | nat_gateway_ips    | list(string) | Public IPs of the NAT gateways                      |
@@ -928,7 +927,7 @@ module "function_app" {
 ##### Inputs
 
 | Variable                                           | Type         | Description                                                                                                             | Required | Default                                |
-|----------------------------------------------------| ------------ |-------------------------------------------------------------------------------------------------------------------------| -------- | -------------------------------------- |
+| -------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------- |
 | name                                               | string       | Name of the function app                                                                                                | yes      |                                        |
 | source_dir                                         | string       | Directory containing the function code                                                                                  | yes      |                                        |
 | location                                           | string       | The Azure region where the resources should be created                                                                  | yes      |                                        |

--- a/aws/lambda/gateway/api.tf
+++ b/aws/lambda/gateway/api.tf
@@ -1,7 +1,7 @@
 resource "aws_api_gateway_rest_api" "api" {
   name                         = var.name
   description                  = var.description
-  disable_execute_api_endpoint = anytrue(var.disable_default_endpoint, local.use_mtls)
+  disable_execute_api_endpoint = anytrue([var.disable_default_endpoint, local.use_mtls])
 }
 
 resource "aws_api_gateway_deployment" "deployment" {

--- a/aws/lambda/gateway/api.tf
+++ b/aws/lambda/gateway/api.tf
@@ -1,6 +1,7 @@
 resource "aws_api_gateway_rest_api" "api" {
-  name        = var.name
-  description = var.description
+  name                         = var.name
+  description                  = var.description
+  disable_execute_api_endpoint = anytrue(var.disable_default_endpoint, local.use_mtls)
 }
 
 resource "aws_api_gateway_deployment" "deployment" {

--- a/aws/lambda/gateway/variables.tf
+++ b/aws/lambda/gateway/variables.tf
@@ -98,6 +98,12 @@ variable "domain" {
   }
 }
 
+variable "disable_default_endpoint" {
+  description = "By default, clients can invoke your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that clients use a custom domain name to invoke your API, disable the default endpoint."
+  type        = bool
+  default     = false
+}
+
 variable "redeployment_trigger" {
   description = "A unique string to force a redeploy of the api gateway. If not set manually, the module will use the configurations for endpoints, api_key, and authorizer config to decide if a redeployment is necessary."
   type        = string


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

Adds option to disable the AWS generated API Gateway endpoint URL. Enforces that the endpoint URL is disabled whenever we use a mTLS setup to avoid potential security issues.

### PR instructions

- check code changes
- deploy `aws/api_gateway_with_domain_mtls`
  - `terraform init && terraform apply`
  - check the API Gateway in the AWS console, default endpoint must be disabled
  - clean up after testing `terraform destroy`

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
