### PR TITLE
ignore changes to replay_policy in SNS topic subscription lifec…

### DIFF
--- a/aws/sqs/sqs.tf
+++ b/aws/sqs/sqs.tf
@@ -65,4 +65,8 @@ resource "aws_sns_topic_subscription" "main" {
   topic_arn = var.sns_topic_arn_for_subscription
   protocol  = "sqs"
   endpoint  = aws_sqs_queue.main.arn
+
+  lifecycle {
+    ignore_changes = [replay_policy]
+  }
 }


### PR DESCRIPTION
closes #116

<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->
#### Context
We had an error by a deployment because of a missing required field of the attribute replay policy. The first idea was to add the attribute to the terraform module but  itdoes not seem to have a very practical use case at the moment. 
Therefore, since we want to keep on using SNS message replay in the future, this small fix prevents the terraform error from happening.

### PR instructions
- you could test this by deploying on your local environment the example packages sns_fifo and then sqs_fifo:
- for sqs_fifo, you will need the output of sns_fifo, that you will add as the value of the variable `sns_topic_arn_for_subscription`
- when this is done, go to the AWS console, to the resulting SNS topic subscription and click on `Start Replay`. 
- After this, you will see a `Status="Completed"`
- go back to the terraform example and use `terraform plan`
- Before the lifecycle addition, you would've seen that the replay policy values would change. Now there should be no changes
<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
