### PR TITLE
add option to push alb access logs to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,10 @@ module "auto-scaling-group" {
   multi_az_nat = true
   manual_lifecycle = false
   manual_lifecycle_timeout = 300
+  access_logs = {
+    bucket = "they-test-logs"
+    prefix = "asg-logs"
+  }
 }
 
 ```
@@ -689,7 +693,7 @@ module "auto-scaling-group" {
 ##### Inputs
 
 | Variable                           | Type         | Description                                                                                                                                  | Required | Default                                                                   |
-| ---------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
+|------------------------------------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------|----------|---------------------------------------------------------------------------|
 | name                               | string       | Name of the Auto Scaling group (ASG)                                                                                                         | yes      |                                                                           |
 | ami_id                             | string       | ID of AMI used in EC2 instances of ASG                                                                                                       | yes      |                                                                           |
 | instance_type                      | string       | Instance type used to deploy instances in ASG                                                                                                | yes      |                                                                           |
@@ -723,6 +727,9 @@ module "auto-scaling-group" {
 | loadbalancer_disabled              | bool         | Specify true to use the ASG without an ELB. By default, an ELB will be used                                                                  | no       | `false`                                                                   |
 | manual_lifecycle                   | bool         | Specify true to force the asg to wait until lifecycle actions are completed before adding instances to the load balancer                     | no       | `false`                                                                   |
 | manual_lifecycle_timeout           | number       | The maximum time, in seconds, that an instance can remain in a Pending:Wait state                                                            | no       | `null`                                                                    |
+| access_logs                        | object       | Enables access logs                                                                                                                          | no       | `null`                                                                    |
+| access_logs.bucket                 | string       | Name of the bucket where the access logs are stored                                                                                          | (yes)    |                                                                           |
+| access_logs.prefix                 | string       | Prefix for access logs within the s3 bucket, use this to set the folder within the bucket                                                    | (yes)    |                                                                           |
 
 ##### Outputs
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Collection of modules to provide an easy way to create and deploy common infrast
     - [SNS](#sns)
     - [API Gateway (REST)](#api-gateway-rest)
     - [S3 Bucket](#s3-bucket)
+    - [S3 Log Bucket Policy](#s3-log-bucket-policy)
     - [Auto Scaling group](#auto-scaling-group)
     - [CloudFront Distribution](#cloudfront-distribution)
     - [Azure OpenID role](#azure-openid-role)
@@ -617,6 +618,28 @@ module "s3_bucket" {
 | id         | string | ID of the s3 bucket            |
 | arn        | string | ARN of the s3 bucket           |
 | versioning | string | ID of the s3 bucket versioning |
+
+#### S3 Log Bucket Policy
+
+```hcl
+module "s3_log_bucket_policy" {
+  source = "github.com/THEY-Consulting/they-terraform//aws/s3-bucket/log-bucket-policy"
+
+  bucket_name = "my-bucket"
+}
+```
+
+##### Inputs
+
+| Variable | Type   | Description        | Required | Default |
+|----------|--------|--------------------| -------- | ------- |
+| name     | string | Name of the bucket | yes      |         |
+
+##### Outputs
+
+| Output   | Type         | Description                                             |
+|----------|--------------|---------------------------------------------------------|
+| policies | list(object) | List of policies that can be used in a policy statement |
 
 #### Auto Scaling group
 

--- a/aws/auto-scaling-group/application-load-balancer.tf
+++ b/aws/auto-scaling-group/application-load-balancer.tf
@@ -6,8 +6,17 @@ resource "aws_lb" "lb" {
   subnets            = aws_subnet.alb_public_subnets[*].id
   internal           = false # False for internet-facing ALBs.
 
+  dynamic "access_logs" {
+    for_each = var.access_logs != null ? [var.access_logs] : []
+    content {
+      bucket  = access_logs.value["bucket"]
+      prefix  = "${access_logs.value["prefix"]}/${var.name}-lb-access-logs"
+      enabled = true
+    }
+  }
+
   tags = merge(var.tags,
-  { Name = "${var.name}" })
+  { Name = var.name })
 }
 
 resource "aws_lb_listener" "lb_listener_only_http" {

--- a/aws/auto-scaling-group/variables.tf
+++ b/aws/auto-scaling-group/variables.tf
@@ -174,3 +174,12 @@ variable "manual_lifecycle_timeout" {
   type        = number
   default     = null
 }
+
+variable "access_logs" {
+  description = "Enables access logs"
+  type = object({
+    bucket = string
+    prefix = string
+  })
+  default = null
+}

--- a/aws/s3-bucket/log-bucket-policy/output.tf
+++ b/aws/s3-bucket/log-bucket-policy/output.tf
@@ -1,0 +1,57 @@
+data "aws_region" "current" {}
+data "aws_elb_service_account" "main" {}
+
+output "policies" {
+  value = [
+    {
+      Effect = "Allow"
+      Principal = {
+        AWS = [data.aws_elb_service_account.main.arn]
+      }
+      Action   = ["s3:PutObject"]
+      Resource = "arn:aws:s3:::${var.bucket_name}/*",
+    },
+    {
+      Effect = "Allow"
+      Principal = {
+        Service = ["delivery.logs.amazonaws.com"]
+      }
+      Action   = ["s3:PutObject"]
+      Resource = "arn:aws:s3:::${var.bucket_name}/*",
+      Condition = {
+        StringEquals = {
+          "s3:x-amz-acl" = "bucket-owner-full-control"
+        }
+      }
+    },
+    {
+      Effect = "Allow"
+      Principal = {
+        Service = ["delivery.logs.amazonaws.com"]
+      }
+      Action   = ["s3:GetBucketAcl"]
+      Resource = "arn:aws:s3:::${var.bucket_name}",
+    },
+    {
+      Effect = "Allow"
+      Principal = {
+        Service = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      }
+      Action   = ["s3:GetBucketAcl"]
+      Resource = "arn:aws:s3:::${var.bucket_name}",
+    },
+    {
+      Effect = "Allow"
+      Principal = {
+        Service = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      }
+      Action   = ["s3:PutObject"]
+      Resource = "arn:aws:s3:::${var.bucket_name}/*",
+      Condition = {
+        StringEquals = {
+          "s3:x-amz-acl" = "bucket-owner-full-control"
+        }
+      }
+    }
+  ]
+}

--- a/aws/s3-bucket/log-bucket-policy/variables.tf
+++ b/aws/s3-bucket/log-bucket-policy/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+}

--- a/examples/aws/auto-scaling-group-with-lb-logs/.terraform.lock.hcl
+++ b/examples/aws/auto-scaling-group-with-lb-logs/.terraform.lock.hcl
@@ -1,0 +1,63 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.85.0"
+  constraints = "~> 5.26"
+  hashes = [
+    "h1:GMbL2QaWKOdFOWfcH5Yu/o7RMwmK0LrIDjVYnDFr368=",
+    "zh:047bfefb24b64de7fdac48d85ab0950591c96092ca093d530cc61a54ffbb0f21",
+    "zh:1c459bab3e99fc760ddb57b935965888c38ebff032b451927a277c00a60f382c",
+    "zh:568df3a039ae4ca3a0e9591a4b3dbc3a23b8efeee8cd64e0abf860aa03b0630b",
+    "zh:7463d353c8c47030a7489238e53b9ef86ebbf4b8ce0628d6b0b293795fc85c50",
+    "zh:7639c24e110aec4145a792238c86aa1b70881e1dedfc2b51ca12d32f92fc3a9d",
+    "zh:893c8a8542c2cec74168094d9f8cc05e6cfadc02d9be2ee63c6564b00c4d608c",
+    "zh:8e0f0c3352b6099e2e44fd5c644f9a27830207c667c45b56a103f756a5731828",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f138a702f568cc891ab377a32d1baaf5b3baa93f80e50a0e36dfd642b1a15a4",
+    "zh:c1e1752ef5d8539e400e297f78a83ddf3d888a40139e48abfbb92d561b524981",
+    "zh:ce7af121ba5587925ce488d7514269fcab3f77562e9d10195e16359b1be3cf00",
+    "zh:d78df6b63765f3829f0fc664ca9be3bbcbe3a0b5c072c8b81b259b55530f2d52",
+    "zh:e14a5f0a5091eb20583763a2e4a75191de0355edf98aaab2904d487124e05877",
+    "zh:eb893b3c2cc3fc26db278ed9fff10c1c5a1bcdf40b37fe44f6073f79d1a93031",
+    "zh:f741f29f4d1a570a6ccbf5e139747d417177bc7cd00f039ca657d81d456e304e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.3"
+  hashes = [
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
+    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
+    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
+    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
+    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
+    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
+    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
+    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
+    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
+    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
+    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.3"
+  hashes = [
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/examples/aws/auto-scaling-group-with-lb-logs/auto-scaling-group-with-lb-logs.tf
+++ b/examples/aws/auto-scaling-group-with-lb-logs/auto-scaling-group-with-lb-logs.tf
@@ -1,0 +1,70 @@
+# --- DATA ---
+
+data "aws_availability_zones" "azs" {
+  state = "available"
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+locals {
+  bucket_name = "they-test-s3-bucket-${random_string.suffix.id}"
+}
+
+# --- RESOURCES / MODULES ---
+
+module "s3_log_bucket_policy" {
+  # source = "github.com/THEY-Consulting/they-terraform//aws/s3-bucket/log-bucket-policy"
+  source = "../../../aws/s3-bucket/log-bucket-policy"
+
+  bucket_name = local.bucket_name
+}
+
+module "s3_bucket" {
+  # source = "github.com/THEY-Consulting/they-terraform//aws/s3-bucket"
+  source = "../../../aws/s3-bucket"
+
+  # bucket names are blocked for some time (approx. 1hr) after destroy, therefore use a random suffix to create unique names
+  name       = local.bucket_name
+  versioning = false
+
+  prevent_destroy = false # disable protection for testing purposes, don't do this in production
+
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = module.s3_log_bucket_policy.policies
+  })
+}
+
+
+module "auto-scaling-group" {
+  # source = "github.com/THEY-Consulting/they-terraform//aws/auto-scaling-group"
+  source = "../../../aws/auto-scaling-group"
+
+  name                = "${substr(terraform.workspace, 0, 5)}-they-terraform-asg-lb-logs"
+  ami_id              = "ami-0ba27d9989b7d8c5d" # AMI valid for eu-central-1 (Amazon Linux 2023 arm64).
+  instance_type       = "t4g.nano"
+  desired_capacity    = 1
+  min_size            = 1
+  max_size            = 1
+  user_data_file_name = "user_data.sh"
+  availability_zones  = data.aws_availability_zones.azs.names[*] # Use AZs of region defined by provider.
+
+  access_logs = {
+    bucket = module.s3_bucket.id
+    prefix = "asg-lb-logs-example"
+  }
+}
+
+# --- OUTPUT ---
+
+output "alb_dns" {
+  value = module.auto-scaling-group.alb_dns
+}
+
+output "s3_bucket" {
+  value = module.s3_bucket.id
+}

--- a/examples/aws/auto-scaling-group-with-lb-logs/providers.tf
+++ b/examples/aws/auto-scaling-group-with-lb-logs/providers.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.26"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "they-terraform-examples-tfstate"
+    encrypt        = true
+    dynamodb_table = "they-terraform-examples-tfstate-lock"
+    key            = "auto-scaling-group-with-lb-logs/terraform.tfstate"
+    region         = "eu-central-1"
+  }
+
+  required_version = "1.6.4"
+}
+
+// default provider that is used when no other provider
+// is specified explicitly
+provider "aws" {
+  region = "eu-central-1"
+
+  default_tags {
+    tags = {
+      Project   = "they-terraform-examples"
+      CreatedBy = "terraform"
+    }
+  }
+}

--- a/examples/aws/auto-scaling-group-with-lb-logs/user_data.sh
+++ b/examples/aws/auto-scaling-group-with-lb-logs/user_data.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Respond with a webpage with the private IP of the instance on port 80.
+mkdir /var/www
+touch /var/www/index.html
+echo "<h1>Hostname: $(hostname -f)</h1>" > /var/www/index.html
+cd /var/www
+python3 -m http.server 80


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

- deploy new `examples/aws/auto-scaling-group-with-lb-logs` example
  - call `alb_dns` from output 
  - check the logs are created within the s3 bucket (may take a few minutes)
- deploy any other auto-scaling-group example to check it still works without settings `access_logs`

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
