### PR TITLE
add function response types to lambda event source mapping

### DIFF
--- a/aws/lambda/trigger.tf
+++ b/aws/lambda/trigger.tf
@@ -69,6 +69,7 @@ resource "aws_lambda_permission" "bucket_trigger_lambda_func_permission" {
 resource "aws_lambda_event_source_mapping" "sqs_trigger_lambda" {
   count = var.sqs_trigger != null ? 1 : 0
 
-  event_source_arn = var.sqs_trigger.arn
-  function_name    = aws_lambda_function.lambda_func.function_name
+  event_source_arn        = var.sqs_trigger.arn
+  function_name           = aws_lambda_function.lambda_func.function_name
+  function_response_types = ["ReportBatchItemFailures"]
 }

--- a/aws/lambda/trigger.tf
+++ b/aws/lambda/trigger.tf
@@ -69,7 +69,8 @@ resource "aws_lambda_permission" "bucket_trigger_lambda_func_permission" {
 resource "aws_lambda_event_source_mapping" "sqs_trigger_lambda" {
   count = var.sqs_trigger != null ? 1 : 0
 
-  event_source_arn        = var.sqs_trigger.arn
-  function_name           = aws_lambda_function.lambda_func.function_name
+  event_source_arn = var.sqs_trigger.arn
+  function_name    = aws_lambda_function.lambda_func.function_name
+  # this is necessary since we use Promise<SQSBatchResponse> as the return type of our sync lambdas
   function_response_types = ["ReportBatchItemFailures"]
 }


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions
- review code changes
- to test these changes, follow the instructions for this [PR](https://github.com/THEY-Consulting/cp-api/pull/494)
- ensure everything works as expected

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
