### PR TITLE
changes in aws/cloudfront/domain.tf

### DIFF
--- a/aws/cloudfront/domain.tf
+++ b/aws/cloudfront/domain.tf
@@ -1,13 +1,14 @@
 data "aws_region" "current" {}
 
 data "aws_route53_zone" "main" {
-  name = local.root_domain
+  count = var.attach_domain ? 1 : 0
+  name  = local.root_domain
 }
 
 resource "aws_route53_record" "frontend" {
   count = var.attach_domain ? 1 : 0
 
-  zone_id = data.aws_route53_zone.main.zone_id
+  zone_id = data.aws_route53_zone.main[0].zone_id
   name    = local.domain_without_protocol
   type    = "A"
 


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

This pull request includes a change to the `aws/cloudfront/domain.tf` file to conditionally attach a domain based on a variable. Fix when using sub domain and not root domain. In thath case root_domain would not be found, during look up.

Changes to conditional domain attachment:

* [`aws/cloudfront/domain.tf`](diffhunk://#diff-4a0a28b5d48ba363f3ad415eaf5c7110b1c4b9806b00d0188fab2b00a48d56f0R4-R11): Added a conditional count to the `aws_route53_zone` data source and updated the `zone_id` reference in the `aws_route53_record` resource to use the first element of the `aws_route53_zone.main` array.

### PR instructions

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
