### PR TITLE
add option to send aws lambda logs to datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ module "lambda" {
   }
 
   mount_efs = aws_efs_access_point.main.arn
+  
+  dd_api_key = "datadog-api-key-123"
+  dd_site    = "datadoghq.eu"
+  dd_service = "they-lambda"
 
   tags = {
     createdBy = "terraform"
@@ -251,7 +255,7 @@ module "lambda" {
 ##### Inputs
 
 | Variable                      | Type         | Description                                                                                                                        | Required | Default                    |
-| ----------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
+|-------------------------------| ------------ |------------------------------------------------------------------------------------------------------------------------------------| -------- |----------------------------|
 | name                          | string       | Name of the lambda function                                                                                                        | yes      |                            |
 | description                   | string       | Description of the lambda function                                                                                                 | yes      |                            |
 | source_dir                    | string       | Directory containing the lambda function                                                                                           | yes      |                            |
@@ -294,6 +298,9 @@ module "lambda" {
 | vpc_config.security_group_ids | list(string) | List of security groups to connect the lambda with                                                                                 | (yes)    |                            |
 | vpc_config.subnet_ids         | list(string) | List of subnets to attach to the lambda                                                                                            | (yes)    |                            |
 | mount_efs                     | string       | ARN of the EFS file system to mount                                                                                                | no       | `null`                     |
+| dd_api_key                    | string       | Datadog API key, when this is set, logs are forwared to datadog                                                                    | no       | `null`                     |
+| dd_site                       | string       | Datadog site                                                                                                                       | no       | `"datadoghq.eu"`           |
+| dd_service                    | string       | Sets the service name within datadog                                                                                               | no       | `""`                       |
 | tags                          | map(string)  | Map of tags to assign to the Lambda Function and related resources                                                                 | no       | `{}`                       |
 
 ##### Outputs

--- a/aws/lambda/cloudwatch.tf
+++ b/aws/lambda/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "log_group" {
-  name              = "/aws/lambda/${aws_lambda_function.lambda_func.function_name}"
+  name              = "/aws/lambda/${local.lambda_func.function_name}"
   retention_in_days = var.cloudwatch.retention_in_days
 
   tags = var.tags

--- a/aws/lambda/lambda.tf
+++ b/aws/lambda/lambda.tf
@@ -1,3 +1,7 @@
+locals {
+  lambda_func = var.dd_api_key == null ? aws_lambda_function.lambda_func[0] : module.lambda-datadog[0]
+}
+
 # use data source to build and zip the function app,
 # this way terraform can decide during plan stage
 # if publishing is required or not
@@ -17,6 +21,8 @@ data "archive_file" "function_zip" {
 }
 
 resource "aws_lambda_function" "lambda_func" {
+  count = var.dd_api_key == null ? 1 : 0
+
   function_name    = var.name
   description      = var.description
   filename         = data.archive_file.function_zip.output_path
@@ -52,6 +58,46 @@ resource "aws_lambda_function" "lambda_func" {
       local_mount_path = "/mnt/efs"
     }
   }
+
+  tags = var.tags
+}
+
+module "lambda-datadog" {
+  count = var.dd_api_key != null ? 1 : 0
+
+  source  = "DataDog/lambda-datadog/aws"
+  version = "2.0.0"
+
+  environment_variables = merge({
+    #     "DD_API_KEY_SECRET_ARN" : # TODO
+    "DD_API_KEY" : var.dd_api_key
+    "DD_ENV" : terraform.workspace
+    "DD_SERVICE" : var.dd_service
+    "DD_SITE" : var.dd_site
+    #     "DD_VERSION" : var.version_tag # TODO?
+  }, var.environment)
+
+  # AWS_lambda_function arguments, these get passed to the lambda function.
+  function_name    = var.name
+  description      = var.description
+  filename         = data.archive_file.function_zip.output_path
+  source_code_hash = data.archive_file.function_zip.output_base64sha256
+  role             = var.role_arn != null ? var.role_arn : aws_iam_role.role.0.arn
+  handler          = var.handler == "index.handler" && var.build.enabled ? "${var.build.build_dir}/index.handler" : var.handler
+  runtime          = var.runtime
+  architectures    = var.architectures
+  publish          = var.publish
+  memory_size      = var.memory_size
+  timeout          = var.timeout
+  layers           = var.layers # TODO: can this be done inside this module?
+
+  # Blocks are transformed, for more details see:
+  # https://github.com/DataDog/terraform-aws-lambda-datadog?tab=readme-ov-file#inputs
+  vpc_config_security_group_ids = var.vpc_config != null ? var.vpc_config.security_group_ids : null
+  vpc_config_subnet_ids         = var.vpc_config != null ? var.vpc_config.subnet_ids : null
+
+  file_system_config_arn              = var.mount_efs != null ? var.mount_efs : null
+  file_system_config_local_mount_path = "/mnt/efs"
 
   tags = var.tags
 }

--- a/aws/lambda/output.tf
+++ b/aws/lambda/output.tf
@@ -1,13 +1,13 @@
 output "arn" {
-  value = aws_lambda_function.lambda_func.arn
+  value = local.lambda_func.arn
 }
 
 output "function_name" {
-  value = aws_lambda_function.lambda_func.function_name
+  value = local.lambda_func.function_name
 }
 
 output "invoke_arn" {
-  value = aws_lambda_function.lambda_func.invoke_arn
+  value = local.lambda_func.invoke_arn
 }
 
 output "build" {

--- a/aws/lambda/trigger.tf
+++ b/aws/lambda/trigger.tf
@@ -14,7 +14,7 @@ resource "aws_cloudwatch_event_target" "cw_event_target" {
   count = var.cron_trigger != null ? 1 : 0
 
   target_id = coalesce(var.cron_trigger.name, "target-${var.name}")
-  arn       = aws_lambda_function.lambda_func.arn
+  arn       = local.lambda_func.arn
   rule      = aws_cloudwatch_event_rule.cw_event_rule.0.name
   input = jsonencode({
     body = var.cron_trigger.input
@@ -26,7 +26,7 @@ resource "aws_lambda_permission" "cron_trigger_lambda_func_permission" {
 
   statement_id  = "allow-execution-${aws_cloudwatch_event_rule.cw_event_rule.0.name}"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.lambda_func.function_name
+  function_name = local.lambda_func.function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.cw_event_rule.0.arn
 }
@@ -45,7 +45,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = var.bucket_trigger.bucket
 
   lambda_function {
-    lambda_function_arn = aws_lambda_function.lambda_func.arn
+    lambda_function_arn = local.lambda_func.arn
     events              = var.bucket_trigger.events
     filter_prefix       = var.bucket_trigger.filter_prefix
     filter_suffix       = var.bucket_trigger.filter_suffix
@@ -59,7 +59,7 @@ resource "aws_lambda_permission" "bucket_trigger_lambda_func_permission" {
 
   statement_id  = "allow-execution-${var.bucket_trigger.bucket}-${var.bucket_trigger.name}"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.lambda_func.function_name
+  function_name = local.lambda_func.function_name
   principal     = "s3.amazonaws.com"
   source_arn    = data.aws_s3_bucket.source.0.arn
 }
@@ -70,7 +70,7 @@ resource "aws_lambda_event_source_mapping" "sqs_trigger_lambda" {
   count = var.sqs_trigger != null ? 1 : 0
 
   event_source_arn = var.sqs_trigger.arn
-  function_name    = aws_lambda_function.lambda_func.function_name
+  function_name    = local.lambda_func.function_name
   # this is necessary since we use Promise<SQSBatchResponse> as the return type of our sync lambdas
   function_response_types = ["ReportBatchItemFailures"]
 }

--- a/aws/lambda/variables.tf
+++ b/aws/lambda/variables.tf
@@ -153,6 +153,25 @@ variable "layers" {
   default     = []
 }
 
+variable "dd_api_key" {
+  description = "Datadog API key."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "dd_site" {
+  description = "Datadog site."
+  type        = string
+  default     = "datadoghq.eu"
+}
+
+variable "dd_service" {
+  description = "Sets the service name within datadog."
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "Map of tags to assign to the Lambda Function and related resources."
   type        = map(string)

--- a/examples/aws/lambda_with_diagnostics/.terraform.lock.hcl
+++ b/examples/aws/lambda_with_diagnostics/.terraform.lock.hcl
@@ -1,0 +1,63 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.0"
+  hashes = [
+    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.77.0"
+  constraints = ">= 5.77.0, ~> 5.77.0"
+  hashes = [
+    "h1:7yv9NDANq8B0hKcxySR053tYoG8rKHC2EobEEXjUdDg=",
+    "zh:0bb61ed8a86a231e466ceffd010cb446418483853aa7e35ecb628cf578fa3905",
+    "zh:15d37511e55db46a50e703195858b816b7bbfd7bd6d193abf45aec1cb31cfc29",
+    "zh:1cdaec2ca4408e90aee6ea550ff4ff01a46033854c26d71309541975aa6317bd",
+    "zh:1dd2d1af44004b35a1597e82f9aa9d6396a77808371aa4dfd2045a2a144b7329",
+    "zh:329bf790ef57b29b95eee847090bffb74751b2b5e5a4c23e07367cc0bf9cce10",
+    "zh:40949e13342a0a738036e66420b7a546bda91ef68038981badbe454545076f16",
+    "zh:5674eb93c8edd308abac408ae45ee90e59e171d45011f00f5036ff4d43a1de52",
+    "zh:747624ce0e938dd773bca295df226d39d425d3805e6afe50248159d0f2ec6d3a",
+    "zh:761795909c5cba10f138d276384fb034031eb1e8c5cdfe3b93794c8a78d909ce",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b95901dae3f2c7eea870d57940117ef5391676689efc565351bb087816674e4",
+    "zh:9bb86e159828dedc1302844d29ee6d79d6fee732c830a36838c359b9319ab304",
+    "zh:9e72dfbd7c28da259d51af92c21e580efd0045103cba2bb01cd1a8acb4185883",
+    "zh:a226b88521022598d1be8361b4f2976834d305ff58c8ea9b9a12c82f9a23f2c2",
+    "zh:faabcdfa36365359dca214da534cfb2fd5738edb40786c2afd09702f42ad1651",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.4"
+  hashes = [
+    "h1:cCabxnWQ5fX1lS7ZqgUzsvWmKZw9FA7NRxAZ94vcTcc=",
+    "zh:037fd82cd86227359bc010672cd174235e2d337601d4686f526d0f53c87447cb",
+    "zh:0ea1db63d6173d01f2fa8eb8989f0809a55135a0d8d424b08ba5dabad73095fa",
+    "zh:17a4d0a306566f2e45778fbac48744b6fd9c958aaa359e79f144c6358cb93af0",
+    "zh:298e5408ab17fd2e90d2cd6d406c6d02344fe610de5b7dae943a58b958e76691",
+    "zh:38ecfd29ee0785fd93164812dcbe0664ebbe5417473f3b2658087ca5a0286ecb",
+    "zh:59f6a6f31acf66f4ea3667a555a70eba5d406c6e6d93c2c641b81d63261eeace",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:ad0279dfd09d713db0c18469f585e58d04748ca72d9ada83883492e0dd13bd58",
+    "zh:c69f66fd21f5e2c8ecf7ca68d9091c40f19ad913aef21e3ce23836e91b8cbb5f",
+    "zh:d4a56f8c48aa86fc8e0c233d56850f5783f322d6336f3bf1916e293246b6b5d4",
+    "zh:f2b394ebd4af33f343835517e80fc876f79361f4688220833bc3c77655dd2202",
+    "zh:f31982f29f12834e5d21e010856eddd19d59cd8f449adf470655bfd19354377e",
+  ]
+}

--- a/examples/aws/lambda_with_diagnostics/lambda_with_diagnostics.tf
+++ b/examples/aws/lambda_with_diagnostics/lambda_with_diagnostics.tf
@@ -1,0 +1,24 @@
+# --- RESOURCES / MODULES ---
+
+module "lambda_with_diagnostics" {
+  # source = "github.com/THEY-Consulting/they-terraform//aws/lambda"
+  source = "../../../aws/lambda"
+
+  name        = "they-test-diagnostics"
+  description = "Test lambda with diagnostics"
+  source_dir  = "../.packages/lambda-simple"
+  runtime     = "nodejs20.x"
+
+  build = {
+    enabled = false
+  }
+
+  dd_api_key = var.dd_api_key
+  dd_service = "they-terraform-examples"
+}
+
+# --- OUTPUT ---
+
+output "lambda_arn" {
+  value = module.lambda_with_diagnostics.arn
+}

--- a/examples/aws/lambda_with_diagnostics/providers.tf
+++ b/examples/aws/lambda_with_diagnostics/providers.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.77.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "they-terraform-examples-tfstate"
+    encrypt        = true
+    dynamodb_table = "they-terraform-examples-tfstate-lock"
+    key            = "lambda-with-diagnostics/terraform.tfstate"
+    region         = "eu-central-1"
+  }
+
+  required_version = "1.6.4"
+}
+
+// default provider that is used when no other provider
+// is specified explicitly
+provider "aws" {
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      Project   = "they-terraform-examples"
+      CreatedBy = "terraform"
+    }
+  }
+}

--- a/examples/aws/lambda_with_diagnostics/variables.tf
+++ b/examples/aws/lambda_with_diagnostics/variables.tf
@@ -1,0 +1,4 @@
+variable "dd_api_key" {
+  description = "Datadog API key."
+  type        = string
+}


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

- deploy an old example, e.g. _examples/aws/lambda_without_build_ 
  - should deploy as usual without any errors 
- set `export TF_VAR_dd_api_key=<check 1password: datadog > they-terraform-examples >` in your .envrc 
- deploy the new example  _examples/aws/lambda_with_diagnostics_ 
  - go to the new lambda and trigger a test event
  - check log explorer in datadog, after a few minutes there should appear a log entry from your request

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
