### PR TITLE
remove AzureWebJobsDashboard setting from azure functions

### DIFF
--- a/azure/function-app/function_app-linux.tf
+++ b/azure/function-app/function_app-linux.tf
@@ -30,6 +30,10 @@ resource "azurerm_linux_function_app" "function_app" {
     var.environment
   )
 
+  // This is used to configure the AzureWebJobsDashboard setting.
+  // Since it is deprecated, we disable it
+  builtin_logging_enabled = false
+
   dynamic "identity" {
     for_each = var.identity != null ? [var.identity] : []
     content {

--- a/azure/function-app/function_app-windows.tf
+++ b/azure/function-app/function_app-windows.tf
@@ -28,6 +28,10 @@ resource "azurerm_windows_function_app" "function_app" {
     var.environment
   )
 
+  // This is used to configure the AzureWebJobsDashboard setting.
+  // Since it is deprecated, we disable it
+  builtin_logging_enabled = false
+
   dynamic "identity" {
     for_each = var.identity != null ? [var.identity] : []
     content {


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

This fixes the warning for azure functions

> The Dashboard setting is no longer supported. See https://aka.ms/functions-dashboard for details.

### PR instructions

- deploy any `examples/azure/function_app_...` example
- check the environment variables after deployment in the azure portal, `AzureWebJobsDashboard` should no longer exist

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
