### PR TITLE
fix azure frontdoor no symbols

### DIFF
--- a/azure/frontdoor/main.tf
+++ b/azure/frontdoor/main.tf
@@ -1,3 +1,9 @@
+locals {
+  workspace = replace(terraform.workspace, "-", "")
+  # Determine the full domain name based on the presence of a DNS zone
+  full_domain_name = var.dns_zone_name != null ? "${var.subdomain}.${var.dns_zone_name}" : "${var.subdomain}.${var.domain}"
+}
+
 resource "azurerm_cdn_frontdoor_profile" "fqdn_profile" {
   name                     = "${terraform.workspace}-profile"
   resource_group_name      = var.resource_group.name
@@ -11,7 +17,7 @@ resource "azurerm_cdn_frontdoor_endpoint" "web_endpoint" {
 }
 
 resource "azurerm_cdn_frontdoor_rule_set" "rule_set" {
-  name                     = "${terraform.workspace}caching"
+  name                     = "${local.workspace}caching"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.fqdn_profile.id
 }
 
@@ -71,11 +77,6 @@ resource "azurerm_cdn_frontdoor_rule" "cache_rule" {
       query_string_caching_behavior = "IgnoreQueryString"
     }
   }
-}
-
-# Determine the full domain name
-locals {
-  full_domain_name = var.dns_zone_name != null ? "${var.subdomain}.${var.dns_zone_name}" : "${var.subdomain}.${var.domain}"
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain" "custom_domain" {


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

The key changes include moving the `locals` block to the top of the file and replacing direct `terraform.workspace` references with the new `local.workspace` variable.

### Refactoring and reorganization:

* Moved the `locals` block, containing `workspace` and `full_domain_name` definitions, to the top of the file for better visibility and organization.
* Updated the `name` attribute in the `azurerm_cdn_frontdoor_rule_set` resource to use `local.workspace` instead of directly referencing `terraform.workspace`, ensuring name has no symbols from workspace.

### PR instructions

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
