### PR TITLE
sqs - add queue url to output

### DIFF
--- a/aws/sqs/output.tf
+++ b/aws/sqs/output.tf
@@ -6,12 +6,20 @@ output "queue_name" {
   value = aws_sqs_queue.main.name
 }
 
+output "queue_url" {
+  value = aws_sqs_queue.main.url
+}
+
 output "dlq_arn" {
   value = var.dead_letter_queue_config == null ? null : aws_sqs_queue.dlq[0].arn
 }
 
 output "dlq_queue_name" {
   value = var.dead_letter_queue_config == null ? null : aws_sqs_queue.dlq[0].name
+}
+
+output "dlq_queue_url" {
+  value = var.dead_letter_queue_config == null ? null : aws_sqs_queue.dlq[0].url
 }
 
 output "topic_subscription_arn" {


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

Adds the queue urls to the output of the sqs module. This URL is needed when creating a SQS consumer which is not a lambda trigger. We previously only had lambda triggers for SQS queues and therefore did not need it.

### PR instructions

- check code changes

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
