### PR TITLE
add nsg_name to vm output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1363,14 +1363,15 @@ module "vm" {
 
 ##### Outputs
 
-| Output                    | Type   | Description                      |
-|---------------------------|--------|----------------------------------|
-| public_ip                 | string | Public ip if enabled             |
-| network_name              | string | Name of the network              |
-| subnet_id                 | string | Id of the subnet                 |
-| network_security_group_id | string | Id of the network security group |
-| vm_username               | string | Admin username                   |
-| vm_id                     | string | Id of the VM                     |
+| Output                    | Type   | Description                        |
+|---------------------------|--------|------------------------------------|
+| public_ip                 | string | Public ip if enabled               |
+| network_name              | string | Name of the network                |
+| subnet_id                 | string | Id of the subnet                   |
+| network_security_group_id | string | Id of the network security group   |
+| vm_username               | string | Admin username                     |
+| vm_id                     | string | Id of the VM                       |
+| nsg_name                  | string | Name of the network security group |
 
 #### Container Instances
 

--- a/azure/vm/output.tf
+++ b/azure/vm/output.tf
@@ -21,3 +21,7 @@ output "vm_username" {
 output "vm_id" {
   value = azurerm_linux_virtual_machine.main[0].id
 }
+
+output "nsg_name" {
+  value = azurerm_network_security_group.main.name
+}

--- a/examples/azure/vm/vm.tf
+++ b/examples/azure/vm/vm.tf
@@ -31,6 +31,10 @@ output "vm_id" {
   value = module.vm.vm_id
 }
 
+output "nsg_name" {
+  value = module.vm.nsg_name
+}
+
 output "connect_instructions" {
   value = "Connect to your VM with: ssh -i ${path.cwd}/insecure-key ${module.vm.vm_username}@${module.vm.public_ip}"
 }


### PR DESCRIPTION
<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

This pull request adds a new output variable, `nsg_name`, to the Azure Virtual Machine module and updates related documentation and examples to include this new output.

### Updates to Outputs:

* **`README.md`**: Added an entry for the `nsg_name` output in the Outputs table, describing it as the "Name of the network security group."

* **`azure/vm/output.tf`**: Introduced a new output variable, `nsg_name`, which outputs the name of the network security group using `azurerm_network_security_group.main.name`.

* **`examples/azure/vm/vm.tf`**: Added an output for `nsg_name` in the example configuration, making it accessible in example deployments of the module.

### PR instructions

- use example to check new output

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
