### PR TITLE
add id to cloudfront output

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,10 +812,11 @@ module "cloudfront_distribution" {
 ##### Outputs
 
 | Output         | Type   | Description                                   |
-| -------------- | ------ | --------------------------------------------- |
+|----------------| ------ |-----------------------------------------------|
 | domain_name    | string | Domain name of the CloudFront distribution    |
 | hosted_zone_id | string | Hosted zone id of the CloudFront distribution |
 | arn            | string | ARN of the CloudFront distribution            |
+| id             | string | Id of the CloudFront distribution             |
 
 #### Azure OpenID role
 

--- a/aws/cloudfront/output.tf
+++ b/aws/cloudfront/output.tf
@@ -9,3 +9,7 @@ output "hosted_zone_id" {
 output "arn" {
   value = aws_cloudfront_distribution.s3_distribution.arn
 }
+
+output "id" {
+  value = aws_cloudfront_distribution.s3_distribution.id
+}

--- a/examples/aws/cloudfront-distribution/main.tf
+++ b/examples/aws/cloudfront-distribution/main.tf
@@ -56,3 +56,7 @@ output "hosted_zone_id" {
 output "domain" {
   value = local.domain
 }
+
+output "id" {
+  value = module.cloudfront_distribution.id
+}


### PR DESCRIPTION
This pull request adds a new output, `id`, to the CloudFront distribution module and updates relevant documentation and examples to reflect this change.

### Updates to CloudFront distribution module:

* [`aws/cloudfront/output.tf`](diffhunk://#diff-1527fb38ec44b3ae9a528c2b111d18f78f8767f51ddf0be2b029e8b06208af8cR12-R15): Added a new output, `id`, to expose the ID of the CloudFront distribution.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L815-R819): Updated the outputs table to include the new `id` field for the CloudFront distribution.

### Example updates:

* [`examples/aws/cloudfront-distribution/main.tf`](diffhunk://#diff-93155e96b98107e63556705f32c3e2a825734412f9dd0d5f8263f41c2c01bf45R59-R62): Added the `id` output to the example usage of the CloudFront distribution module.

<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
