### PR TITLE
add front door endpoint name to module output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1905,8 +1905,9 @@ module "frontdoor_backend" {
 | endpoint_url                   | string | The URL of the Front Door endpoint         |
 | custom_domain_url              | string | The URL of the custom domain               |
 | cdn_frontdoor_profile_id       | string | The ID of the Front Door profile           |
-| cdn_frontdoor_endpoint_id      | string | The ID of the Front Door endpoint          |
 | cdn_frontdoor_name             | string | The name of the Front Door profile         |
+| cdn_frontdoor_endpoint_id      | string | The ID of the Front Door endpoint          |
+| cdn_frontdoor_endpoint_name    | string | The name of the Front Door endpoint        |
 | custom_domain_validation_token | string | The validation token for the custom domain |
 | endpoint_host_name             | string | The host name of the Front Door endpoint   |
 | route_id                       | string | The ID of the Front Door route             |

--- a/azure/frontdoor/outputs.tf
+++ b/azure/frontdoor/outputs.tf
@@ -18,6 +18,11 @@ output "cdn_frontdoor_endpoint_id" {
   value       = azurerm_cdn_frontdoor_endpoint.endpoint.id
 }
 
+output "cdn_frontdoor_endpoint_name" {
+  description = "The name of the Front Door endpoint"
+  value       = azurerm_cdn_frontdoor_endpoint.endpoint.name
+}
+
 output "custom_domain_validation_token" {
   description = "The validation token for the custom domain"
   value       = azurerm_cdn_frontdoor_custom_domain.custom_domain.validation_token


### PR DESCRIPTION
This pull request updates the documentation and Terraform outputs for the Azure Front Door module to include a new output for the endpoint name and ensure consistency in the documentation. The most important changes are as follows:

### Documentation updates:
* In `README.md`, added a new entry for `cdn_frontdoor_endpoint_name` to document the name of the Front Door endpoint. Additionally, reordered `cdn_frontdoor_endpoint_id` to maintain logical grouping.

### Terraform outputs:
* In `azure/frontdoor/outputs.tf`, added a new output `cdn_frontdoor_endpoint_name` to expose the name of the Front Door endpoint in the Terraform module.

<!-- Before creating a PR

✔ I rechecked the ticket and all requirements are fulfilled.

✔ I checked the Readme and made sure it is up-to-date.

✔ I added tests for the new code if possible.

✔ I rebased the feature branch on the main branch.

✔ I linked the ticket to this PR by either
  - adding `closes #issueId` if PR should close the issue
  - or adding `for #issueId` if PR should relate to an issue

✔ I enabled auto-merge if the PR can be merged after approval

✔ I informed my colleagues in slack about the PR / offered a walkthrough

-->

### PR instructions

- deploy the azure frontdoor example

<!--
✔ I wrote clear instructions how to set up and test the PR.

✔ I executed the PR instructions myself and everything worked.

- `cd applications/theyray`
- `terraform workspace new 621` (or use your own workspace)
- `terraform apply`
- wait forever...

-->

### The steps of acceptance

✔ I executed the PR instructions and everything worked.

✔ I checked the requirements for the ticket, and they are matching the PR.

✔ I am satisfied with the code and left annotations if I had some ideas.
