### PR TITLE
Feature/frontdoor spa routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1801,6 +1801,7 @@ module "frontdoor_web" {
   # Web-specific configuration for static website hosting
   web = {
     primary_web_host = "mystorageaccount.z6.web.core.windows.net"
+    is_spa           = true # Enable Single Page Application routing
   }
 
   # Domain configuration
@@ -1880,6 +1881,7 @@ module "frontdoor_backend" {
 | frontdoor_profile.name                       | string       | The name of the existing Front Door profile                                                                                                                      | (yes)    |                                                                                       |
 | web                                          | object       | Configuration for web/frontend usage with storage account. Use this for static website hosting                                                                   | no*      | `null`                                                                                |
 | web.primary_web_host                         | string       | Primary web host of the storage account                                                                                                                          | (yes)    |                                                                                       |
+| web.is_spa                                   | bool         | Enable routing for single page application                                                                                                                       | no       | `false`                                                                                 |
 | backend                                      | object       | Configuration for backend API services                                                                                                                           | no*      | `null`                                                                                |
 | backend.host                                 | string       | Backend host (VM IP, App Service, etc.)                                                                                                                          | (yes)    |                                                                                       |
 | backend.host_header                          | string       | Host header to send to the backend                                                                                                                               | no       | Value of backend.host                                                                 |

--- a/azure/frontdoor/main.tf
+++ b/azure/frontdoor/main.tf
@@ -115,15 +115,15 @@ resource "azurerm_cdn_frontdoor_rule" "cache_rule" {
 
 # Redirect rules for single page applications (only relevant for web spa mode)
 resource "azurerm_cdn_frontdoor_rule" "spa_rewrite" {
-  count                      = local.is_web_mode && var.web.is_spa ? 1 : 0
-  name                       = "sparewrite"
-  cdn_frontdoor_rule_set_id  = azurerm_cdn_frontdoor_rule_set.rule_set.id
-  order                      = 2
-  behavior_on_match          = "Continue"
+  count                     = local.is_web_mode && var.web.is_spa ? 1 : 0
+  name                      = "sparewrite"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.rule_set.id
+  order                     = 2
+  behavior_on_match         = "Continue"
 
   conditions {
     url_path_condition {
-      operator     = "Any"
+      operator = "Any"
     }
   }
 

--- a/azure/frontdoor/main.tf
+++ b/azure/frontdoor/main.tf
@@ -123,14 +123,13 @@ resource "azurerm_cdn_frontdoor_rule" "spa_rewrite" {
 
   conditions {
     url_path_condition {
-      operator     = "Equal"
-      match_values = ["/*"]
+      operator     = "Any"
     }
   }
 
   actions {
     url_rewrite_action {
-      source_pattern          = "/(.*)"
+      source_pattern          = "/"
       destination             = "/index.html"
       preserve_unmatched_path = false
     }

--- a/azure/frontdoor/main.tf
+++ b/azure/frontdoor/main.tf
@@ -116,7 +116,7 @@ resource "azurerm_cdn_frontdoor_rule" "cache_rule" {
 # Redirect rules for single page applications (only relevant for web spa mode)
 resource "azurerm_cdn_frontdoor_rule" "spa_rewrite" {
   count                      = local.is_web_mode && var.web.is_spa ? 1 : 0
-  name                       = "spa-rewrite"
+  name                       = "sparewrite"
   cdn_frontdoor_rule_set_id  = azurerm_cdn_frontdoor_rule_set.rule_set.id
   order                      = 2
   behavior_on_match          = "Continue"

--- a/azure/frontdoor/main.tf
+++ b/azure/frontdoor/main.tf
@@ -113,6 +113,30 @@ resource "azurerm_cdn_frontdoor_rule" "cache_rule" {
   }
 }
 
+# Redirect rules for single page applications (only relevant for web spa mode)
+resource "azurerm_cdn_frontdoor_rule" "spa_rewrite" {
+  count                      = local.is_web_mode && var.web.is_spa ? 1 : 0
+  name                       = "spa-rewrite"
+  cdn_frontdoor_rule_set_id  = azurerm_cdn_frontdoor_rule_set.rule_set.id
+  order                      = 2
+  behavior_on_match          = "Continue"
+
+  conditions {
+    url_path_condition {
+      operator     = "Equal"
+      match_values = ["/*"]
+    }
+  }
+
+  actions {
+    url_rewrite_action {
+      source_pattern          = "/(.*)"
+      destination             = "/index.html"
+      preserve_unmatched_path = false
+    }
+  }
+}
+
 resource "azurerm_cdn_frontdoor_custom_domain" "custom_domain" {
   name                     = "${var.web != null ? "web" : "backend"}-domain-${terraform.workspace}"
   cdn_frontdoor_profile_id = local.frontdoor_profile_id

--- a/azure/frontdoor/variables.tf
+++ b/azure/frontdoor/variables.tf
@@ -10,7 +10,7 @@ variable "web" {
   description = "Configuration for web/frontend usage with storage account. Use this for static website hosting."
   type = object({
     primary_web_host = string
-    is_spa = optional(bool, false)
+    is_spa           = optional(bool, false)
   })
   default = null
 }

--- a/azure/frontdoor/variables.tf
+++ b/azure/frontdoor/variables.tf
@@ -10,6 +10,7 @@ variable "web" {
   description = "Configuration for web/frontend usage with storage account. Use this for static website hosting."
   type = object({
     primary_web_host = string
+    is_spa = optional(bool, false)
   })
   default = null
 }


### PR DESCRIPTION
This pull request introduces support for Single Page Application (SPA) routing in the `frontdoor_web` module, enabling SPA-friendly configurations for static website hosting. Key changes include updates to documentation, new infrastructure rules for SPA routing, and adjustments to variable definitions.

### SPA Routing Support

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1804): Added an `is_spa` boolean property under the `web` configuration to enable SPA routing, with a default value of `false`. Updated the documentation table to describe its purpose. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1804) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1884)

### Infrastructure Changes

* [`azure/frontdoor/main.tf`](diffhunk://#diff-76b1786519aa17d758e7297c4f3e507c9bd28e7eec09b6735b63eb60512bfb39R116-R138): Introduced a new `azurerm_cdn_frontdoor_rule` resource named `spa_rewrite` to handle SPA routing by rewriting all requests to `/index.html`. This rule is conditionally created based on the `is_spa` property.

### Variable Adjustments

* [`azure/frontdoor/variables.tf`](diffhunk://#diff-61580a5a6ebedf84c71057ece74ff9d24ccd04749ea3cd55cadc05179621dfa9R13): Updated the `web` object variable to include an optional `is_spa` property with a default value of `false`.