### PR TITLE
Feature/pretty azure function logs

### DIFF
--- a/azure/monitoring/datadog/azure-datadog-importer/datadog/index.js
+++ b/azure/monitoring/datadog/azure-datadog-importer/datadog/index.js
@@ -3,7 +3,7 @@
  * Maybe there is a better way to include it as a dependency but for now we have to copy/update it manually.
  * Therefore, we shouldn't change anything in this file, so we can easily copy&paste it from the repo in the future.
  *
- * ‼️We added custom logic to handle azure container apps logs below, see lines 505 - 532 ‼️
+ * ‼️We added custom logic to handle azure container apps logs below, see lines 505 - 537 ‼️
  *
  * Source (2025-04-16):
  * https://github.com/DataDog/datadog-serverless-functions/blob/master/azure/activity_logs_monitoring/index.js

--- a/azure/monitoring/datadog/azure-datadog-importer/datadog/index.js
+++ b/azure/monitoring/datadog/azure-datadog-importer/datadog/index.js
@@ -505,11 +505,16 @@ class EventhubLogHandler {
      * ‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️‼️
      * THIS WAS ADDED BY US. NOT PART OF THE ORIGINAL CODE.
      */
+    // set message based on properties.message to handle azure function logs
+    if (record?.properties?.message) {
+      newRecord['message'] = record.properties.message;
+    }
+
     // Set log status based on properties.Stream to handle azure container apps logs
-    if (record.properties && record.properties.Stream) {
+    if (record?.properties?.Stream) {
       newRecord['status'] = record.properties.Stream === 'stderr' ? 'error' : 'info';
 
-      if (record.properties?.Log) {
+      if (record.properties.Log) {
         try {
           // Try to parse as JSON (for structured logs like Pino)
           const log = JSON.parse(record.properties.Log);


### PR DESCRIPTION
This pull request introduces a small update to the custom logic for handling Azure container apps logs in the `azure/monitoring/datadog/azure-datadog-importer/datadog/index.js` file. The main change is the addition of logic to properly set the log message for Azure function logs based on the `properties.message` field.

Custom Azure log handling:

* Added logic to set the `message` field in `newRecord` if `record.properties.message` is present, improving support for Azure function logs.
* Updated the comment to reflect the new custom logic now spans lines 505–537.