### PR TITLE
fix(aws/lambda): prevent trigger disconnection on Lambda replacement

### DIFF
--- a/aws/lambda/trigger.tf
+++ b/aws/lambda/trigger.tf
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_event_target" "cw_event_target" {
 resource "aws_lambda_permission" "cron_trigger_lambda_func_permission" {
   count = var.cron_trigger != null ? 1 : 0
 
-  statement_id  = "allow-execution-${aws_cloudwatch_event_rule.cw_event_rule.0.name}"
+  statement_id  = "allow-execution-${aws_cloudwatch_event_rule.cw_event_rule.0.name}-${substr(local.lambda_func.arn, -8, 8)}"
   action        = "lambda:InvokeFunction"
   function_name = local.lambda_func.function_name
   principal     = "events.amazonaws.com"
@@ -57,7 +57,7 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
 resource "aws_lambda_permission" "bucket_trigger_lambda_func_permission" {
   count = var.bucket_trigger != null ? 1 : 0
 
-  statement_id  = "allow-execution-${var.bucket_trigger.bucket}-${var.bucket_trigger.name}"
+  statement_id  = "allow-execution-${var.bucket_trigger.bucket}-${var.bucket_trigger.name}-${substr(local.lambda_func.arn, -8, 8)}"
   action        = "lambda:InvokeFunction"
   function_name = local.lambda_func.function_name
   principal     = "s3.amazonaws.com"


### PR DESCRIPTION
Add Lambda ARN suffix to permission statement_id to ensure CloudWatch
Event and S3 bucket triggers remain connected when the Lambda function
is replaced during deployment.

When a Lambda is replaced, AWS automatically deletes associated
permissions but Terraform doesn't recreate them until the next run.
By including the Lambda ARN in the statement_id, the permission is
automatically recreated when the ARN changes.

This approach works for both standard and Datadog-wrapped Lambda
functions without needing replace_triggered_by lifecycle rules.